### PR TITLE
If an empty orderby array is included, the composed query is invalid #87

### DIFF
--- a/src/composer/composer.ts
+++ b/src/composer/composer.ts
@@ -14,6 +14,7 @@ import {
 import * as utils from '../utils';
 import { FieldData, Formatter, FormatOptions } from '../formatter/formatter';
 import { parseQuery } from '../parser/visitor';
+import { isArray } from 'util';
 
 export interface SoqlComposeConfig {
   logging: boolean; // default=false
@@ -186,7 +187,7 @@ export class Compose {
       }
     }
 
-    if (query.orderBy) {
+    if (query.orderBy && (!isArray(query.orderBy) || query.orderBy.length > 0)) {
       output += this.formatter.formatClause('ORDER BY');
       output += ` ${this.parseOrderBy(query.orderBy)}`;
       this.log(output);

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -98,6 +98,20 @@ describe('compose queries', () => {
     const soqlQuery = composeQuery(query);
     expect(soqlQuery).to.equal(`SELECT Id FROM Account WHERE Foo IN ('1', '2', '3') OR Bar = 'foo'`);
   });
+  it('Should not add extraneous order by clauses', () => {
+    const query: Query = {
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+      ],
+      sObject: 'Account',
+      orderBy: [],
+    };
+    const soqlQuery = composeQuery(query);
+    expect(soqlQuery).to.equal(`SELECT Id FROM Account`);
+  });
 });
 
 describe('format queries', () => {


### PR DESCRIPTION
Added check to ensure order by is only added if when an object or array with more than one element is provided

resolves #87