### PR TITLE
IN clause does not allow date literals #92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.4
+
+Feb 25, 2020
+
+1. Date literals were not properly parsed if they were included as part of a SET within a WHERE clause, such as `WHERE IN (TODAY, LAST_N_DAYS:5)`.
+   1. As part of this change, the `dateLiteralVariable` property in the `Condition` will be an array if a variable date literal is included in a SET where clause. Refer to test cases `93` through `98` for examples
+
 ## 2.3.0
 
 Jan 13, 2020

--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ export interface Condition {
   operator: Operator;
   value?: string | string[];
   literalType?: LiteralType | LiteralType[]; // If populated with STRING on compose, the value(s) will be wrapped in "'" if they are not already. - All other values ignored
-  dateLiteralVariable?: number; // not required for compose, will be populated if SOQL is parsed
+  dateLiteralVariable?: number | number[]; // not required for compose, will be populated if SOQL is parsed
 }
 
 export interface OrderByClause {

--- a/src/api/api-models.ts
+++ b/src/api/api-models.ts
@@ -157,7 +157,7 @@ export interface Condition {
   operator: Operator;
   value?: string | string[];
   literalType?: LiteralType | LiteralType[]; // If populated with STRING on compose, the value(s) will be wrapped in "'" if they are not already. - All other values ignored
-  dateLiteralVariable?: number; // not required for compose, will be populated if SOQL is parsed
+  dateLiteralVariable?: number | number[]; // not required for compose, will be populated if SOQL is parsed
 }
 
 export interface OrderByClause {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -564,6 +564,8 @@ export class SoqlParser extends CstParser {
               { ALT: () => this.CONSUME(lexer.Null, { LABEL: 'value' }) },
               { ALT: () => this.CONSUME(lexer.True, { LABEL: 'value' }) },
               { ALT: () => this.CONSUME(lexer.False, { LABEL: 'value' }) },
+              { ALT: () => this.CONSUME(lexer.DateLiteral, { LABEL: 'value' }) },
+              { ALT: () => this.SUBRULE(this.dateNLiteral, { LABEL: 'value' }) },
               { ALT: () => this.CONSUME(lexer.StringIdentifier, { LABEL: 'value' }) },
             ]),
         );

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -1730,6 +1730,89 @@ export const testCases: TestCase[] = [
       sObject: 'CONTACT',
     },
   },
+  {
+    testCase: 93,
+    soql: `SELECT Id FROM Account WHERE CreatedDate IN (TODAY)`,
+    output: {
+      fields: [{ type: 'Field', field: 'Id' }],
+      sObject: 'Account',
+      where: {
+        left: {
+          field: 'CreatedDate',
+          literalType: 'DATE_LITERAL',
+          operator: 'IN',
+          value: ['TODAY'],
+        },
+      },
+    },
+  },
+  {
+    testCase: 94,
+    soql: `SELECT Id FROM Account WHERE CreatedDate IN (TODAY)`,
+    output: {
+      fields: [{ type: 'Field', field: 'Id' }],
+      sObject: 'Account',
+      where: {
+        left: {
+          field: 'CreatedDate',
+          literalType: 'DATE_LITERAL',
+          operator: 'IN',
+          value: ['TODAY'],
+        },
+      },
+    },
+  },
+  {
+    testCase: 95,
+    soql: `SELECT Id FROM Account WHERE CreatedDate IN (TODAY, LAST_N_DAYS:4)`,
+    output: {
+      fields: [{ type: 'Field', field: 'Id' }],
+      sObject: 'Account',
+      where: {
+        left: {
+          field: 'CreatedDate',
+          literalType: ['DATE_LITERAL', 'DATE_N_LITERAL'],
+          operator: 'IN',
+          value: ['TODAY', 'LAST_N_DAYS:4'],
+          dateLiteralVariable: [null, 4],
+        },
+      },
+    },
+  },
+  {
+    testCase: 96,
+    soql: `SELECT Id FROM Account WHERE CreatedDate IN (LAST_N_DAYS:2)`,
+    output: {
+      fields: [{ type: 'Field', field: 'Id' }],
+      sObject: 'Account',
+      where: {
+        left: {
+          field: 'CreatedDate',
+          literalType: 'DATE_N_LITERAL',
+          operator: 'IN',
+          value: ['LAST_N_DAYS:2'],
+          dateLiteralVariable: [2],
+        },
+      },
+    },
+  },
+  {
+    testCase: 98,
+    soql: `SELECT Id FROM Account WHERE CreatedDate IN (LAST_N_DAYS:4, LAST_N_DAYS:7)`,
+    output: {
+      fields: [{ type: 'Field', field: 'Id' }],
+      sObject: 'Account',
+      where: {
+        left: {
+          field: 'CreatedDate',
+          literalType: 'DATE_N_LITERAL',
+          operator: 'IN',
+          value: ['LAST_N_DAYS:4', 'LAST_N_DAYS:7'],
+          dateLiteralVariable: [4, 7],
+        },
+      },
+    },
+  },
 ];
 
 export default testCases;

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -11,7 +11,7 @@ const replacements = [{ matching: / last /i, replace: ' LAST ' }];
 // Uncomment these to easily test one specific query - useful for troubleshooting/bugfixing
 
 // describe.only('parse queries', () => {
-//   const testCase = testCases.find(tc => tc.testCase === 91);
+//   const testCase = testCases.find(tc => tc.testCase === 97);
 //   it(`should correctly parse test case ${testCase.testCase} - ${testCase.soql}`, () => {
 //     const soqlQuery = parseQuery(testCase.soql, testCase.options);
 //     const soqlQueryWithoutUndefinedProps = JSON.parse(JSON.stringify(soqlQuery));


### PR DESCRIPTION
1. Date literals were not properly parsed if they were included as part of a SET within a WHERE clause, such as .
   1. As part of this change, the  property in the  will be an array if a variable date literal is included in a SET where clause. Refer to test cases  through  for examples

resolves #92