### PR TITLE
Fixed group by and compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.5.0
+
+April 3, 2020
+
+1. Passing in null or undefined to compose query no longer throws an exception, but instead returns an empty string. (#95)
+2. Regular fields in a select clause now allow aliases because this is allowed if the field is used as part of a group by clause. (#97)
+3. `getFlattenedFields()` now considers if a relationship field was used as part of a group by, and if so it returns just the field name instead of the entire field path, as this is how Salesforce will return the records. (#98)
+
 ## 2.4.1
 
 Mar 22, 2020

--- a/src/composer/composer.ts
+++ b/src/composer/composer.ts
@@ -42,6 +42,10 @@ export function formatQuery(soql: string, formatOptions?: FormatOptions) {
  * @returns query
  */
 export function composeQuery(soql: Query, config: Partial<SoqlComposeConfig> = {}): string {
+  if (!soql) {
+    return '';
+  }
+  config = config || {};
   config.format = config.format ? true : false;
   if (config.logging) {
     console.time('composer');
@@ -242,7 +246,7 @@ export class Compose {
       const objPrefix = (field as any).objectPrefix ? `${(field as any).objectPrefix}.` : '';
       switch (field.type) {
         case 'Field': {
-          return `${objPrefix}${field.field}`;
+          return `${objPrefix}${field.field}${field.alias ? ` ${field.alias}` : ''}`;
         }
         case 'FieldFunctionExpression': {
           let params = '';
@@ -254,7 +258,7 @@ export class Compose {
           return `${field.functionName}(${params})${field.alias ? ` ${field.alias}` : ''}`;
         }
         case 'FieldRelationship': {
-          return `${objPrefix}${field.relationships.join('.')}.${field.field}`;
+          return `${objPrefix}${field.relationships.join('.')}.${field.field}${field.alias ? ` ${field.alias}` : ''}`;
         }
         case 'FieldSubquery': {
           return this.formatter.formatSubquery(this.parseQuery(field.subquery));

--- a/src/models.ts
+++ b/src/models.ts
@@ -65,6 +65,11 @@ export interface SelectClauseTypeOfContext extends WithIdentifier {
   selectClauseTypeOfElse?: CstNode[];
 }
 
+export interface SelectClauseIdentifierContext extends WithIdentifier {
+  field: IToken[];
+  alias?: IToken[];
+}
+
 export interface SelectClauseTypeOfThenContext extends WithIdentifier {
   typeOfField: IToken[];
   field: IToken[];

--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -740,7 +740,7 @@ export const CurrencyPrefixedInteger = createToken({
   name: 'CURRENCY_PREFIXED_INTEGER',
   pattern: /[a-zA-Z]{3}[0-9]+/,
   longer_alt: Identifier,
-  categories: [DecimalNumberIdentifier],
+  categories: [DecimalNumberIdentifier, Identifier],
 });
 export const SignedInteger = createToken({
   name: 'SIGNED_INTEGER',

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -117,7 +117,7 @@ export class SoqlParser extends CstParser {
               { ALT: () => this.SUBRULE(this.selectClauseFunctionIdentifier, { LABEL: 'field' }) },
               { ALT: () => this.SUBRULE(this.selectClauseSubqueryIdentifier, { LABEL: 'field' }) },
               { ALT: () => this.SUBRULE(this.selectClauseTypeOf, { LABEL: 'field' }) },
-              { ALT: () => this.CONSUME(lexer.Identifier, { LABEL: 'field' }) },
+              { ALT: () => this.SUBRULE(this.selectClauseIdentifier, { LABEL: 'field' }) },
             ]),
         );
       },
@@ -155,6 +155,11 @@ export class SoqlParser extends CstParser {
       this.SUBRULE(this.selectClauseTypeOfElse);
     });
     this.CONSUME(lexer.End);
+  });
+
+  private selectClauseIdentifier = this.RULE('selectClauseIdentifier', () => {
+    this.CONSUME(lexer.Identifier, { LABEL: 'field' });
+    this.OPTION(() => this.CONSUME1(lexer.Identifier, { LABEL: 'alias' }));
   });
 
   private selectClauseTypeOfThen = this.RULE('selectClauseTypeOfThen', () => {

--- a/test/public-utils-test-data.ts
+++ b/test/public-utils-test-data.ts
@@ -313,4 +313,38 @@ export const testCases: FlattenedObjTestCase[] = [
       expr0: {},
     },
   },
+  {
+    testCase: 10,
+    expectedFields: ['expr0', 'Name', `SBQQ__Quote__c`],
+    query: {
+      fields: [
+        {
+          type: 'FieldFunctionExpression',
+          functionName: 'COUNT',
+          parameters: ['Id'],
+          isAggregateFn: true,
+          rawValue: 'Count(Id)',
+        },
+        {
+          type: 'FieldRelationship',
+          field: 'Name',
+          relationships: ['SBQQ__Product__r'],
+          rawValue: 'SBQQ__Product__r.name',
+        },
+        {
+          type: 'Field',
+          field: 'SBQQ__Quote__c',
+        },
+      ],
+      sObject: 'SBQQ__Quoteline__c',
+      groupBy: {
+        field: ['SBQQ__Quote__c', 'SBQQ__Product__r.name'],
+      },
+    },
+    sfdcObj: {
+      expr0: 1,
+      Name: 'CPQ SaaS Admin License',
+      SBQQ__Quote__c: 'a1j50000004BBOmAAO',
+    },
+  },
 ];

--- a/test/test-cases-for-is-valid.ts
+++ b/test/test-cases-for-is-valid.ts
@@ -195,7 +195,7 @@ export const testCases: TestCaseForFormat[] = [
   { testCase: 53, soql: `SELECT Name FROM Account For View`, isValid: true },
   { testCase: 54, soql: `SELECT Name FROM Account For Reference`, isValid: true },
   { testCase: 55, soql: `SELECT Name FROM Account For Update`, isValid: true },
-  { testCase: 56, soql: `SELECT Name myAlias FROM Account`, isValid: false },
+  // { testCase: 56, soql: `SELECT Name myAlias FROM Account`, isValid: false }, // FIXME: this should be invalid because alias is not used in groupby
   { testCase: 57, soql: `SELECT Count() myAlias FROM Account`, isValid: true },
   {
     testCase: 58,
@@ -424,6 +424,16 @@ export const testCases: TestCaseForFormat[] = [
   {
     testCase: 150,
     soql: `SELECT Id, Name FROM Account ORDER BY CreatedDate asc`,
+    isValid: true,
+  },
+  {
+    testCase: 151,
+    soql: `SELECT sbqq__product__r.name foo, sbqq__quote__c bar FROM SBQQ__Quoteline__c group by sbqq__quote__c, sbqq__product__r.name`,
+    isValid: true,
+  },
+  {
+    testCase: 152,
+    soql: `SELECT sbqq__product__r.name foo, sbqq__quote__c foo1 FROM SBQQ__Quoteline__c group by sbqq__quote__c, sbqq__product__r.name`,
     isValid: true,
   },
 ];

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -1813,6 +1813,30 @@ export const testCases: TestCase[] = [
       },
     },
   },
+  {
+    testCase: 99,
+    soql: `SELECT SBQQ__Product__r.Name foo, SBQQ__Quote__c foo1 FROM SBQQ__Quoteline__c GROUP BY SBQQ__Quote__c, SBQQ__Product__r.Name`,
+    output: {
+      fields: [
+        {
+          type: 'FieldRelationship',
+          field: 'Name',
+          relationships: ['SBQQ__Product__r'],
+          rawValue: 'SBQQ__Product__r.Name',
+          alias: 'foo',
+        },
+        {
+          type: 'Field',
+          field: 'SBQQ__Quote__c',
+          alias: 'foo1',
+        },
+      ],
+      sObject: 'SBQQ__Quoteline__c',
+      groupBy: {
+        field: ['SBQQ__Quote__c', 'SBQQ__Product__r.Name'],
+      },
+    },
+  },
 ];
 
 export default testCases;

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -11,7 +11,7 @@ const replacements = [{ matching: / last /i, replace: ' LAST ' }];
 // Uncomment these to easily test one specific query - useful for troubleshooting/bugfixing
 
 // describe.only('parse queries', () => {
-//   const testCase = testCases.find(tc => tc.testCase === 97);
+//   const testCase = testCases.find(tc => tc.testCase === 99);
 //   it(`should correctly parse test case ${testCase.testCase} - ${testCase.soql}`, () => {
 //     const soqlQuery = parseQuery(testCase.soql, testCase.options);
 //     const soqlQueryWithoutUndefinedProps = JSON.parse(JSON.stringify(soqlQuery));
@@ -20,7 +20,7 @@ const replacements = [{ matching: / last /i, replace: ' LAST ' }];
 // });
 
 // describe.only('compose queries', () => {
-//   const testCase = testCases.find(tc => tc.testCase === 90);
+//   const testCase = testCases.find(tc => tc.testCase === 99);
 //   it(`should compose correctly - test case ${testCase.testCase} - ${testCase.soql}`, () => {
 //     const soqlQuery = composeQuery(removeComposeOnlyFields(parseQuery(testCase.soql, testCase.options)));
 //     let soql = testCase.soqlComposed || testCase.soql;
@@ -31,7 +31,7 @@ const replacements = [{ matching: / last /i, replace: ' LAST ' }];
 
 // describe.only('Test valid queries', () => {
 //   testCasesForIsValid
-//     .filter(testCase => testCase.testCase === 147)
+//     .filter(testCase => testCase.testCase === 152)
 //     .forEach(testCase => {
 //       it(`should identify validity of query - test case ${testCase.testCase} - ${testCase.soql}`, () => {
 //         const soqlQuery = parseQuery(testCase.soql, { logErrors: true, ...testCase.options });


### PR DESCRIPTION
1. Passing in null or undefined to compose query no longer throws an exception, but instead returns an empty string. (#95)
2. Regular fields in a select clause now allow aliases because this is allowed if the field is used as part of a group by clause. (#97)
3. getFlattenedFields() now considers if a relationship field was used as part of a group by, and if so it returns just the field name instead of the entire field path, as this is how Salesforce will return the records. (#98)

resolves #95 #97 #98