### PR TITLE
NOT (field expression) fails to parse #122

### DIFF
--- a/src/api/public-utils.ts
+++ b/src/api/public-utils.ts
@@ -1,17 +1,50 @@
-import * as SoqlModels from './api-models';
 import {
   getParams,
+  hasAlias,
   isComposeField,
   isComposeFieldFunction,
   isComposeFieldRelationship,
   isComposeFieldSubquery,
   isComposeFieldTypeof,
+  isFieldSubquery,
+  isGroupByField,
+  isGroupByFn,
+  isHavingClauseWithRightCondition,
+  isNegationCondition,
+  isOrderByField,
+  isOrderByFn,
   isString,
   isSubquery,
-  isFieldSubquery,
+  isValueCondition,
+  isValueFunctionCondition,
+  isValueQueryCondition,
+  isValueWithDateLiteralCondition,
+  isValueWithDateNLiteralCondition,
+  isWhereClauseWithRightCondition,
+  isWhereOrHavingClauseWithRightCondition,
 } from '../utils';
+import * as SoqlModels from './api-models';
 
-export { isSubquery };
+// re-exported utils available as public API
+export {
+  hasAlias,
+  isFieldSubquery,
+  isGroupByField,
+  isGroupByFn,
+  isHavingClauseWithRightCondition,
+  isNegationCondition,
+  isOrderByField,
+  isOrderByFn,
+  isString,
+  isSubquery,
+  isValueCondition,
+  isValueFunctionCondition,
+  isValueQueryCondition,
+  isValueWithDateLiteralCondition,
+  isValueWithDateNLiteralCondition,
+  isWhereClauseWithRightCondition,
+  isWhereOrHavingClauseWithRightCondition,
+};
 
 export type ComposeFieldInput = ComposeField | ComposeFieldFunction | ComposeFieldRelationship | ComposeFieldSubquery | ComposeFieldTypeof;
 
@@ -125,7 +158,7 @@ export function getFlattenedFields(
   const fields = query.fields;
   // if a relationship field is used in a group by, then Salesforce removes the relationship portion of the field in the returned records
   let groupByFields: { [field: string]: string } = {};
-  if (!!query.groupBy && query.groupBy.field) {
+  if (!!query.groupBy && isGroupByField(query.groupBy)) {
     if (!Array.isArray(query.groupBy.field)) {
       query.groupBy.field = [query.groupBy.field];
     }
@@ -181,7 +214,7 @@ export function getFlattenedFields(
         }
         case 'FieldRelationship': {
           const firstRelationship = field.relationships[0].toLowerCase();
-          if (field.alias) {
+          if (hasAlias(field)) {
             return field.alias;
           }
           // If relationship field is used in groupby, then return field instead of full path

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -158,14 +158,15 @@ export class Formatter {
   }
 
   formatWhereClauseOperators(operator: string, whereClause: string): string {
+    const skipNewLineAndIndent = operator === 'NOT';
     if (this.enabled && this.options.whereClauseOperatorsIndented) {
       return `\n\t${operator} ${whereClause}`;
     } else {
-      return `${this.formatAddNewLine(' ')}${operator} ${whereClause}`;
+      return `${this.formatAddNewLine(skipNewLineAndIndent ? '' : ' ', skipNewLineAndIndent)}${operator} ${whereClause}`;
     }
   }
 
-  formatAddNewLine(alt: string = ' '): string {
-    return this.enabled ? `\n` : alt;
+  formatAddNewLine(alt: string = ' ', skipNewLineAndIndent?: boolean): string {
+    return this.enabled && !skipNewLineAndIndent ? `\n` : alt;
   }
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -93,6 +93,7 @@ export interface WhereClauseSubqueryContext {
 
 export interface ConditionExpressionContext {
   logicalOperator?: IToken[];
+  expressionNegation?: CstNode[];
   expression: CstNode[];
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -188,7 +188,6 @@ export interface GeoLocationFunctionContext {
 }
 
 export interface ExpressionContext {
-  logicalPrefix?: IToken[];
   lhs: IToken[] | CstNode[];
   operator: CstNode[]; // ExpressionOperatorContext
   L_PAREN?: IToken[];
@@ -236,7 +235,6 @@ export interface AtomicExpressionContext {
 }
 
 export interface ExpressionWithAggregateFunctionContext {
-  logicalPrefix?: IToken[];
   lhs: IToken[] | CstNode[];
   rhs: CstNode[];
   relationalOperator?: CstNode[];

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -479,6 +479,10 @@ export class SoqlParser extends CstParser {
     'expression',
     (parenCount?: ParenCount, allowSubquery?: boolean, alowAggregateFn?: boolean, allowLocationFn?: boolean) => {
       this.OPTION(() => {
+        this.CONSUME1(lexer.Not, { LABEL: 'logicalPrefix' });
+      });
+
+      this.OPTION1(() => {
         this.MANY(() => {
           this.CONSUME(lexer.LParen);
           if (parenCount) {
@@ -487,7 +491,7 @@ export class SoqlParser extends CstParser {
         });
       });
 
-      this.OPTION1(() => {
+      this.OPTION2(() => {
         this.CONSUME(lexer.Not, { LABEL: 'logicalPrefix' });
       });
 
@@ -504,7 +508,7 @@ export class SoqlParser extends CstParser {
         { ALT: () => this.SUBRULE(this.expressionWithSetOperator, { LABEL: 'operator', ARGS: [allowSubquery] }) },
       ]);
 
-      this.OPTION4(() => {
+      this.OPTION3(() => {
         this.MANY1({
           GATE: () => (parenCount ? parenCount.left > parenCount.right : true),
           DEF: () => {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -232,6 +232,7 @@ export class SoqlParser extends CstParser {
         this.OR([
           { ALT: () => this.CONSUME(lexer.And, { LABEL: 'logicalOperator' }) },
           { ALT: () => this.CONSUME(lexer.Or, { LABEL: 'logicalOperator' }) },
+          { ALT: () => this.CONSUME(lexer.Not, { LABEL: 'logicalPrefix' }) },
         ]);
       });
       this.SUBRULE(this.expression, { ARGS: [parenCount, allowSubquery, alowAggregateFn, allowLocationFn] });
@@ -479,7 +480,7 @@ export class SoqlParser extends CstParser {
     'expression',
     (parenCount?: ParenCount, allowSubquery?: boolean, alowAggregateFn?: boolean, allowLocationFn?: boolean) => {
       this.OPTION(() => {
-        this.CONSUME1(lexer.Not, { LABEL: 'logicalPrefix' });
+        this.CONSUME(lexer.Not, { LABEL: 'logicalPrefix' });
       });
 
       this.OPTION1(() => {
@@ -492,7 +493,7 @@ export class SoqlParser extends CstParser {
       });
 
       this.OPTION2(() => {
-        this.CONSUME(lexer.Not, { LABEL: 'logicalPrefix' });
+        this.CONSUME1(lexer.Not, { LABEL: 'logicalPrefix' });
       });
 
       this.OR1([

--- a/test/test-cases-for-is-valid.ts
+++ b/test/test-cases-for-is-valid.ts
@@ -446,5 +446,25 @@ export const testCases: TestCaseForFormat[] = [
     soql: `SELECT AnnualRevenue FROM Account WHERE ((NOT AnnualRevenue > 0) AND AnnualRevenue < 200000) LIMIT 1`,
     isValid: true,
   },
+  {
+    testCase: 155,
+    soql: `SELECT Id FROM Account WHERE ((NOT (Name = '2' OR Name = '3')))`,
+    isValid: true,
+  },
+  {
+    testCase: 156,
+    soql: `SELECT Id FROM Account WHERE NOT (Name = '2' OR Name = '3')`,
+    isValid: true,
+  },
+  {
+    testCase: 157,
+    soql: `SELECT Id FROM Account WHERE NOT (Name = '2')`,
+    isValid: true,
+  },
+  {
+    testCase: 158,
+    soql: `SELECT Id FROM Account WHERE NOT Name = '2'`,
+    isValid: true,
+  },
 ];
 export default testCases;

--- a/test/test-cases-for-is-valid.ts
+++ b/test/test-cases-for-is-valid.ts
@@ -436,5 +436,15 @@ export const testCases: TestCaseForFormat[] = [
     soql: `SELECT sbqq__product__r.name foo, sbqq__quote__c foo1 FROM SBQQ__Quoteline__c group by sbqq__quote__c, sbqq__product__r.name`,
     isValid: true,
   },
+  {
+    testCase: 153,
+    soql: `SELECT AnnualRevenue FROM Account WHERE NOT (AnnualRevenue > 0 AND AnnualRevenue < 200000)`,
+    isValid: true,
+  },
+  {
+    testCase: 154,
+    soql: `SELECT AnnualRevenue FROM Account WHERE ((NOT AnnualRevenue > 0) AND AnnualRevenue < 200000) LIMIT 1`,
+    isValid: true,
+  },
 ];
 export default testCases;

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -526,21 +526,25 @@ export const testCases: TestCase[] = [
         right: {
           left: {
             openParen: 1,
-            logicalPrefix: 'NOT',
-            field: 'Id',
-            operator: '=',
-            value: "'2'",
-            literalType: 'STRING',
-            closeParen: 1,
           },
-          operator: 'OR',
+          operator: 'NOT',
           right: {
-            left: { openParen: 1, field: 'Name', operator: 'LIKE', value: "'%FOO%'", literalType: 'STRING' },
+            left: {
+              field: 'Id',
+              operator: '=',
+              value: "'2'",
+              literalType: 'STRING',
+              closeParen: 1,
+            },
             operator: 'OR',
             right: {
-              left: { openParen: 1, field: 'Name', operator: 'LIKE', value: "'%ARM%'", literalType: 'STRING' },
-              operator: 'AND',
-              right: { left: { field: 'FOO', operator: '=', value: "'bar'", literalType: 'STRING', closeParen: 3 } },
+              left: { openParen: 1, field: 'Name', operator: 'LIKE', value: "'%FOO%'", literalType: 'STRING' },
+              operator: 'OR',
+              right: {
+                left: { openParen: 1, field: 'Name', operator: 'LIKE', value: "'%ARM%'", literalType: 'STRING' },
+                operator: 'AND',
+                right: { left: { field: 'FOO', operator: '=', value: "'bar'", literalType: 'STRING', closeParen: 3 } },
+              },
             },
           },
         },
@@ -1563,14 +1567,16 @@ export const testCases: TestCase[] = [
           },
           operator: 'AND',
           right: {
-            left: {
-              openParen: 1,
-              closeParen: 1,
-              logicalPrefix: 'NOT',
-              field: 'Name',
-              operator: 'IN',
-              value: [`'4/30 testing account'`, `'amendment quote doc testing'`],
-              literalType: 'STRING',
+            left: { openParen: 1 },
+            operator: 'NOT',
+            right: {
+              left: {
+                closeParen: 1,
+                field: 'Name',
+                operator: 'IN',
+                value: [`'4/30 testing account'`, `'amendment quote doc testing'`],
+                literalType: 'STRING',
+              },
             },
           },
         },
@@ -1924,22 +1930,25 @@ export const testCases: TestCase[] = [
       fields: [{ type: 'Field', field: 'AnnualRevenue' }],
       sObject: 'Account',
       where: {
-        left: {
-          field: 'AnnualRevenue',
-          logicalPrefix: 'NOT',
-          openParen: 1,
-          operator: '>',
-          value: '0',
-          literalType: 'INTEGER',
-        },
-        operator: 'AND',
+        left: null,
+        operator: 'NOT',
         right: {
           left: {
             field: 'AnnualRevenue',
-            closeParen: 1,
-            operator: '<',
-            value: '200000',
+            openParen: 1,
+            operator: '>',
+            value: '0',
             literalType: 'INTEGER',
+          },
+          operator: 'AND',
+          right: {
+            left: {
+              field: 'AnnualRevenue',
+              closeParen: 1,
+              operator: '<',
+              value: '200000',
+              literalType: 'INTEGER',
+            },
           },
         },
       },
@@ -1953,22 +1962,51 @@ export const testCases: TestCase[] = [
       sObject: 'Account',
       where: {
         left: {
-          field: 'AnnualRevenue',
-          logicalPrefix: 'NOT',
           openParen: 2,
-          closeParen: 1,
-          operator: '>',
-          value: '0',
-          literalType: 'INTEGER',
         },
-        operator: 'AND',
+        operator: 'NOT',
         right: {
           left: {
             field: 'AnnualRevenue',
             closeParen: 1,
-            operator: '<',
-            value: '200000',
+            operator: '>',
+            value: '0',
             literalType: 'INTEGER',
+          },
+          operator: 'AND',
+          right: {
+            left: {
+              field: 'AnnualRevenue',
+              closeParen: 1,
+              operator: '<',
+              value: '200000',
+              literalType: 'INTEGER',
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    testCase: 105,
+    soql: `SELECT Id FROM Account WHERE NOT Id = '2'`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+      ],
+      sObject: 'Account',
+      where: {
+        left: null,
+        operator: 'NOT',
+        right: {
+          left: {
+            field: 'Id',
+            operator: '=',
+            value: "'2'",
+            literalType: 'STRING',
           },
         },
       },

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -1917,6 +1917,63 @@ export const testCases: TestCase[] = [
       },
     },
   },
+  {
+    testCase: 103,
+    soql: 'SELECT AnnualRevenue FROM Account WHERE NOT (AnnualRevenue > 0 AND AnnualRevenue < 200000)',
+    output: {
+      fields: [{ type: 'Field', field: 'AnnualRevenue' }],
+      sObject: 'Account',
+      where: {
+        left: {
+          field: 'AnnualRevenue',
+          logicalPrefix: 'NOT',
+          openParen: 1,
+          operator: '>',
+          value: '0',
+          literalType: 'INTEGER',
+        },
+        operator: 'AND',
+        right: {
+          left: {
+            field: 'AnnualRevenue',
+            closeParen: 1,
+            operator: '<',
+            value: '200000',
+            literalType: 'INTEGER',
+          },
+        },
+      },
+    },
+  },
+  {
+    testCase: 104,
+    soql: 'SELECT AnnualRevenue FROM Account WHERE ((NOT AnnualRevenue > 0) AND AnnualRevenue < 200000)',
+    output: {
+      fields: [{ type: 'Field', field: 'AnnualRevenue' }],
+      sObject: 'Account',
+      where: {
+        left: {
+          field: 'AnnualRevenue',
+          logicalPrefix: 'NOT',
+          openParen: 2,
+          closeParen: 1,
+          operator: '>',
+          value: '0',
+          literalType: 'INTEGER',
+        },
+        operator: 'AND',
+        right: {
+          left: {
+            field: 'AnnualRevenue',
+            closeParen: 1,
+            operator: '<',
+            value: '200000',
+            literalType: 'INTEGER',
+          },
+        },
+      },
+    },
+  },
 ];
 
 export default testCases;

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -20,32 +20,36 @@ const replacements = [{ matching: / last /i, replace: ' LAST ' }];
 //   });
 // });
 
-describe.only('compose queries', () => {
-  const testCase = testCases.find(tc => tc.testCase === 103 || tc.testCase === 104);
-  it(`should compose correctly - test case ${testCase.testCase} - ${testCase.soql}`, () => {
-    const soqlQuery = composeQuery(removeComposeOnlyFields(parseQuery(testCase.soql, testCase.options)));
-    let soql = testCase.soqlComposed || testCase.soql;
-    replacements.forEach(replacement => (soql = soql.replace(replacement.matching, replacement.replace)));
-    expect(soqlQuery).to.equal(soql);
-  });
-});
-
-// describe.only('Test valid queries', () => {
-//   testCasesForIsValid
-//     .filter(testCase => testCase.testCase === 154)
-//     .forEach(testCase => {
-//       it(`should identify validity of query - test case ${testCase.testCase} - ${testCase.soql}`, () => {
-//         const soqlQuery = parseQuery(testCase.soql, { logErrors: true, ...testCase.options });
-//         const isValid = isQueryValid(testCase.soql);
-//         expect(isValid).equal(testCase.isValid);
-//       });
-//       // it(`should identify valid queries - test case ${testCase.testCase} - ${testCase.soql}`, () => {
-//       //   const isValid = isQueryValid(testCase.soql);
-//       //   expect(isValid).equal(testCase.isValid);
-//       //   expect(parseQuery(testCase.soql, testCase.options)).to.not.throw;
-//       // });
-//     });
+// describe.only('compose queries', () => {
+//   const testCase = testCases.find(tc => tc.testCase === 103 || tc.testCase === 104);
+//   it(`should compose correctly - test case ${testCase.testCase} - ${testCase.soql}`, () => {
+//     const soqlQuery = composeQuery(removeComposeOnlyFields(parseQuery(testCase.soql, testCase.options)));
+//     let soql = testCase.soqlComposed || testCase.soql;
+//     replacements.forEach(replacement => (soql = soql.replace(replacement.matching, replacement.replace)));
+//     expect(soqlQuery).to.equal(soql);
+//   });
 // });
+
+describe.only('Test valid queries', () => {
+  testCasesForIsValid
+    .filter(testCase => testCase.isValid)
+    .forEach(testCase => {
+      it(`should identify valid queries - test case ${testCase.testCase} - ${testCase.soql}`, () => {
+        const isValid = isQueryValid(testCase.soql, testCase.options);
+        expect(parseQuery(testCase.soql, testCase.options)).to.not.throw;
+        expect(isValid).equal(testCase.isValid);
+      });
+    });
+
+  testCasesForIsValid
+    .filter(testCase => !testCase.isValid)
+    .forEach(testCase => {
+      it(`should identify invalid queries - test case ${testCase.testCase} - ${testCase.soql}`, () => {
+        const isValid = isQueryValid(testCase.soql, testCase.options);
+        expect(isValid).equal(testCase.isValid);
+      });
+    });
+});
 
 describe('parse queries', () => {
   testCases.forEach(testCase => {

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -11,27 +11,28 @@ const replacements = [{ matching: / last /i, replace: ' LAST ' }];
 // Uncomment these to easily test one specific query - useful for troubleshooting/bugfixing
 
 // describe.only('parse queries', () => {
-//   const testCase = testCases.find(tc => tc.testCase === 102);
+//   const testCase = testCases.find(tc => tc.testCase === 103);
 //   it(`should correctly parse test case ${testCase.testCase} - ${testCase.soql}`, () => {
 //     const soqlQuery = parseQuery(testCase.soql, testCase.options);
+//     console.log(soqlQuery);
 //     const soqlQueryWithoutUndefinedProps = JSON.parse(JSON.stringify(soqlQuery));
 //     expect(testCase.output).to.deep.equal(soqlQueryWithoutUndefinedProps);
 //   });
 // });
 
-// describe.only('compose queries', () => {
-//   const testCase = testCases.find(tc => tc.testCase === 99);
-//   it(`should compose correctly - test case ${testCase.testCase} - ${testCase.soql}`, () => {
-//     const soqlQuery = composeQuery(removeComposeOnlyFields(parseQuery(testCase.soql, testCase.options)));
-//     let soql = testCase.soqlComposed || testCase.soql;
-//     replacements.forEach(replacement => (soql = soql.replace(replacement.matching, replacement.replace)));
-//     expect(soqlQuery).to.equal(soql);
-//   });
-// });
+describe.only('compose queries', () => {
+  const testCase = testCases.find(tc => tc.testCase === 103 || tc.testCase === 104);
+  it(`should compose correctly - test case ${testCase.testCase} - ${testCase.soql}`, () => {
+    const soqlQuery = composeQuery(removeComposeOnlyFields(parseQuery(testCase.soql, testCase.options)));
+    let soql = testCase.soqlComposed || testCase.soql;
+    replacements.forEach(replacement => (soql = soql.replace(replacement.matching, replacement.replace)));
+    expect(soqlQuery).to.equal(soql);
+  });
+});
 
 // describe.only('Test valid queries', () => {
 //   testCasesForIsValid
-//     .filter(testCase => testCase.testCase === 152)
+//     .filter(testCase => testCase.testCase === 154)
 //     .forEach(testCase => {
 //       it(`should identify validity of query - test case ${testCase.testCase} - ${testCase.soql}`, () => {
 //         const soqlQuery = parseQuery(testCase.soql, { logErrors: true, ...testCase.options });


### PR DESCRIPTION
Added failing unit tests
fixed parser to account for NOT prior to parentheses

### TODO
- [ ] Figure out how to distinguish NOT with 1 following condition vs multiple

The way the data model and parser is setup, there is not a good way to distinguish the following cases:
`SELECT AnnualRevenue FROM Account WHERE NOT (AnnualRevenue > 0 AND AnnualRevenue < 200000) LIMIT 1`
`SELECT AnnualRevenue FROM Account WHERE ((NOT AnnualRevenue > 0) AND AnnualRevenue < 200000) LIMIT 1`

### EDIT
This bug will likely require some changes to the data model and will require changes to parsing and visiting nodes to account for a valid query like this `SELECT Id FROM Account WHERE ((NOT (Name = '2' OR Name = '3')))` with the ability to compose back into soql.


resolves #122


Here is how this is handled by mulesoft's Java implementation:
![image](https://user-images.githubusercontent.com/5461649/95683303-a4f69700-0ba7-11eb-9bdc-11ebbd194183.png)
