### PR TITLE
getFlattenedFields does not correctly handle alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.1
+
+January 7, 20201
+
+1. `getFlattenedFields` did not properly handle the alias for an aggregate function within an aggregate query. (#131)
+
 ## 3.0.0
 
 October 14, 2020

--- a/src/api/public-utils.ts
+++ b/src/api/public-utils.ts
@@ -192,6 +192,10 @@ export function getFlattenedFields(
             return param;
           });
 
+          if (field.alias && (field.isAggregateFn || isAggregateResult)) {
+            return field.alias;
+          }
+
           if (field.alias) {
             const firstParam = params[0];
             // Include the full path and replace the field with the alias

--- a/test/public-utils-test-data.ts
+++ b/test/public-utils-test-data.ts
@@ -414,4 +414,32 @@ export const testCases: FlattenedObjTestCase[] = [
       },
     },
   },
+  {
+    testCase: 13,
+    expectedFields: ['AccountId', 'AcctCreatedDate'],
+    query: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'AccountId',
+        },
+        {
+          type: 'FieldFunctionExpression',
+          functionName: 'MAX',
+          parameters: ['Account.CreatedDate'],
+          isAggregateFn: true,
+          rawValue: 'MAX(Account.CreatedDate)',
+          alias: 'AcctCreatedDate',
+        },
+      ],
+      sObject: 'Contact',
+      groupBy: {
+        field: ['AccountId'],
+      },
+    },
+    sfdcObj: {
+      AccountId: '0016g00000ETu0HAAT',
+      AcctCreatedDate: '2020-02-28T03:00:31.000+0000',
+    },
+  },
 ];


### PR DESCRIPTION
... for grouped expressions

Added check to return alias instead of related field for aggregate exp

resolves #31