### PR TITLE
Improve apex bind variable parsing #155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## 4.2.0
 
-June 7, 2021
+June 8, 2021
 
 #155 - Apex bind variable support is improved to allow parsing of more complex Apex.
+
+Review test cases 112 - 117 for examples of supported apex bind variables.
 
 ## 4.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 4.1.0
+## 4.2.0
+
+June 7, 2021
+
+#155 - Apex bind variable support is improved to allow parsing of more complex Apex.
+
+## 4.1.1
 
 June 6, 2021
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -201,7 +201,31 @@ export interface ExpressionContext {
 }
 
 export interface ApexBindVariableExpressionContext {
-  Identifier: IToken[];
+  apex: (CstNode | IToken)[];
+  COLON: IToken[];
+  DECIMAL?: IToken[];
+}
+
+export interface ApexBindVariableNewInstantiationContext {
+  NEW: IToken[];
+  FUNCTION: IToken[];
+  apexBindVariableGeneric?: CstNode[];
+  apexBindVariableFunctionParams: CstNode[];
+}
+export interface ApexBindVariableFunctionCallContext {
+  FUNCTION: IToken[];
+  apexBindVariableFunctionParams: CstNode[];
+}
+export interface ApexBindVariableGenericContext {
+  COMMA: IToken[];
+  GREATER_THAN: IToken[];
+  LESS_THAN: IToken[];
+  PARAMETER: IToken[];
+}
+export interface ApexBindVariableFunctionParamsContext {
+  L_PAREN: IToken[];
+  R_PAREN: IToken[];
+  PARAMETER?: IToken[];
 }
 
 export interface ExpressionOperatorContext {

--- a/src/models.ts
+++ b/src/models.ts
@@ -201,31 +201,47 @@ export interface ExpressionContext {
 }
 
 export interface ApexBindVariableExpressionContext {
-  apex: (CstNode | IToken)[];
+  apex: CstNode[];
   COLON: IToken[];
   DECIMAL?: IToken[];
 }
 
+export interface ApexBindVariableIdentifierContext {
+  Identifier: IToken[];
+  apexBindVariableFunctionArrayAccessor?: CstNode[];
+}
+
 export interface ApexBindVariableNewInstantiationContext {
-  NEW: IToken[];
-  FUNCTION: IToken[];
+  new: IToken[];
+  function: IToken[];
   apexBindVariableGeneric?: CstNode[];
   apexBindVariableFunctionParams: CstNode[];
+  apexBindVariableFunctionArrayAccessor?: CstNode[];
 }
+
 export interface ApexBindVariableFunctionCallContext {
-  FUNCTION: IToken[];
+  function: IToken[];
   apexBindVariableFunctionParams: CstNode[];
+  apexBindVariableFunctionArrayAccessor?: CstNode[];
 }
+
 export interface ApexBindVariableGenericContext {
   COMMA: IToken[];
   GREATER_THAN: IToken[];
   LESS_THAN: IToken[];
-  PARAMETER: IToken[];
+  parameter: IToken[];
 }
+
 export interface ApexBindVariableFunctionParamsContext {
   L_PAREN: IToken[];
   R_PAREN: IToken[];
-  PARAMETER?: IToken[];
+  parameter?: IToken[];
+}
+
+export interface ApexBindVariableFunctionArrayAccessorContext {
+  L_SQUARE_BRACKET: IToken[];
+  R_SQUARE_BRACKET: IToken[];
+  value: IToken[];
 }
 
 export interface ExpressionOperatorContext {

--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -750,6 +750,8 @@ export const Comma = createToken({ name: 'COMMA', pattern: ',', categories: [Sym
 export const Asterisk = createToken({ name: 'ASTERISK', pattern: '*', categories: [SymbolIdentifier] });
 export const LParen = createToken({ name: 'L_PAREN', pattern: '(', categories: [SymbolIdentifier] });
 export const RParen = createToken({ name: 'R_PAREN', pattern: ')', categories: [SymbolIdentifier] });
+export const LSquareBracket = createToken({ name: 'L_SQUARE_BRACKET', pattern: '[', categories: [SymbolIdentifier] });
+export const RSquareBracket = createToken({ name: 'R_SQUARE_BRACKET', pattern: ']', categories: [SymbolIdentifier] });
 export const Plus = createToken({ name: 'PLUS', pattern: '+', categories: [SymbolIdentifier] });
 export const Minus = createToken({ name: 'MINUS', pattern: '-', categories: [SymbolIdentifier] });
 
@@ -1037,6 +1039,8 @@ export const allTokens = [
   Asterisk,
   LParen,
   RParen,
+  LSquareBracket,
+  RSquareBracket,
   Plus,
   Minus,
 ];

--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -263,6 +263,7 @@ export const AboveOrBelow = createToken({
   longer_alt: Identifier,
   categories: [Keyword, Identifier],
 });
+export const ApexNew = createToken({ name: 'new', pattern: /new/i, longer_alt: Identifier, categories: [Keyword, Identifier] });
 export const At = createToken({ name: 'AT', pattern: /AT/i, longer_alt: Identifier, categories: [Keyword, Identifier] });
 export const Below = createToken({ name: 'BELOW', pattern: /BELOW/i, longer_alt: Identifier, categories: [Keyword, Identifier] });
 export const DataCategory = createToken({
@@ -913,6 +914,7 @@ export const allTokens = [
 
   AboveOrBelow,
   Above,
+  ApexNew,
   At,
   Below,
   DataCategory,

--- a/test/test-cases-for-is-valid.ts
+++ b/test/test-cases-for-is-valid.ts
@@ -466,5 +466,22 @@ export const testCases: TestCaseForFormat[] = [
     soql: `SELECT Id FROM Account WHERE NOT Name = '2'`,
     isValid: true,
   },
+  {
+    testCase: 158,
+    options: { allowApexBindVariables: true },
+    soql: `
+SELECT Id
+FROM Account
+WHERE
+  Id IN :new Map<
+    Id,
+    SObject
+  >
+  (someVar)
+  .getSomeClass()
+  .records
+    `,
+    isValid: true,
+  },
 ];
 export default testCases;

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -2346,6 +2346,50 @@ export const testCases: TestCase[] = [
       },
     },
   },
+  {
+    testCase: 116,
+    options: { allowApexBindVariables: true },
+    soql: `SELECT Id FROM SBQQ__QuoteTerm__c WHERE SBQQ__StandardTerm__c = :CPQ_Hard_Coded_Ids__c.getInstance().Standard_Quote_Term_Id__c`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+      ],
+      sObject: 'SBQQ__QuoteTerm__c',
+      where: {
+        left: {
+          field: 'SBQQ__StandardTerm__c',
+          literalType: 'APEX_BIND_VARIABLE',
+          operator: '=',
+          value: 'CPQ_Hard_Coded_Ids__c.getInstance().Standard_Quote_Term_Id__c',
+        },
+      },
+    },
+  },
+  {
+    testCase: 117,
+    options: { allowApexBindVariables: true },
+    soql: `SELECT Id FROM Opportunity WHERE SBQQ__StandardTerm__c = :quotes[3].SBQQ__QuoteLine__r[0].Term__c`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+      ],
+      sObject: 'Opportunity',
+      where: {
+        left: {
+          field: 'SBQQ__StandardTerm__c',
+          literalType: 'APEX_BIND_VARIABLE',
+          operator: '=',
+          value: 'quotes[3].SBQQ__QuoteLine__r[0].Term__c',
+        },
+      },
+    },
+  },
 ];
 
 export default testCases;

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -2265,18 +2265,85 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 112,
-    options: { allowApexBindVariables: true, ignoreParseErrors: true },
+    options: { allowApexBindVariables: true },
     soql: `SELECT Id, (SELECT Id FROM Contacts WHERE Id IN :contactMap.keySet()) FROM Account WHERE Id IN :accountMap.keySet()`,
-    soqlComposed: `SELECT Id, (SELECT Id FROM Contacts) FROM Account`,
     output: {
       fields: [
         {
           type: 'Field',
           field: 'Id',
         },
-        { type: 'FieldSubquery', subquery: { fields: [{ type: 'Field', field: 'Id' }], relationshipName: 'Contacts' } },
+        {
+          type: 'FieldSubquery',
+          subquery: {
+            fields: [{ type: 'Field', field: 'Id' }],
+            relationshipName: 'Contacts',
+            where: { left: { field: 'Id', literalType: 'APEX_BIND_VARIABLE', operator: 'IN', value: 'contactMap.keySet()' } },
+          },
+        },
       ],
       sObject: 'Account',
+      where: { left: { field: 'Id', literalType: 'APEX_BIND_VARIABLE', operator: 'IN', value: 'accountMap.keySet()' } },
+    },
+  },
+  {
+    testCase: 113,
+    options: { allowApexBindVariables: true, ignoreParseErrors: true },
+    soql: `SELECT Id, (SELECT Id FROM Contacts WHERE Id IN :contact_900Map.keySet()) FROM Account WHERE Id IN :acco INVALID untMap.keySet()`,
+    soqlComposed: `SELECT Id, (SELECT Id FROM Contacts WHERE Id IN :contact_900Map.keySet()) FROM Account`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+        {
+          type: 'FieldSubquery',
+          subquery: {
+            fields: [{ type: 'Field', field: 'Id' }],
+            relationshipName: 'Contacts',
+            where: { left: { field: 'Id', literalType: 'APEX_BIND_VARIABLE', operator: 'IN', value: 'contact_900Map.keySet()' } },
+          },
+        },
+      ],
+      sObject: 'Account',
+    },
+  },
+  {
+    testCase: 114,
+    options: { allowApexBindVariables: true },
+    soql: `SELECT Id FROM Account WHERE Id IN :new Map<Id, SObject>(someVar).keySet()`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+      ],
+      sObject: 'Account',
+      where: { left: { field: 'Id', literalType: 'APEX_BIND_VARIABLE', operator: 'IN', value: 'new Map<Id, SObject>(someVar).keySet()' } },
+    },
+  },
+  {
+    testCase: 115,
+    options: { allowApexBindVariables: true },
+    soql: `SELECT Id FROM Account WHERE Id IN :new Map<Id, SObject>(someVar).getSomeClass().records`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+      ],
+      sObject: 'Account',
+      where: {
+        left: {
+          field: 'Id',
+          literalType: 'APEX_BIND_VARIABLE',
+          operator: 'IN',
+          value: 'new Map<Id, SObject>(someVar).getSomeClass().records',
+        },
+      },
     },
   },
 ];

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -12,7 +12,7 @@ const replacements = [{ matching: / last /i, replace: ' LAST ' }];
 // Uncomment these to easily test one specific query - useful for troubleshooting/bugfixing
 
 // describe.only('parse queries', () => {
-//   const testCase = testCases.find(tc => tc.testCase === 62);
+//   const testCase = testCases.find(tc => tc.testCase === 117);
 //   it(`should correctly parse test case ${testCase.testCase} - ${testCase.soql}`, () => {
 //     const soqlQuery = parseQuery(testCase.soql, testCase.options);
 //     console.log(soqlQuery);

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -12,7 +12,7 @@ const replacements = [{ matching: / last /i, replace: ' LAST ' }];
 // Uncomment these to easily test one specific query - useful for troubleshooting/bugfixing
 
 // describe.only('parse queries', () => {
-//   const testCase = testCases.find(tc => tc.testCase === 109);
+//   const testCase = testCases.find(tc => tc.testCase === 62);
 //   it(`should correctly parse test case ${testCase.testCase} - ${testCase.soql}`, () => {
 //     const soqlQuery = parseQuery(testCase.soql, testCase.options);
 //     console.log(soqlQuery);


### PR DESCRIPTION
Improved support for apex expressions

Added test-cases for the following queries:
* `SELECT Id, (SELECT Id FROM Contacts WHERE Id IN :contactMap.keySet()) FROM Account WHERE Id IN :accountMap.keySet()`
* `SELECT Id, (SELECT Id FROM Contacts WHERE Id IN :contact_900Map.keySet()) FROM Account WHERE Id IN :acco INVALID untMap.keySet()`
* `SELECT Id FROM Account WHERE Id IN :new Map<Id, SObject>(someVar).keySet()`
* `SELECT Id FROM Account WHERE Id IN :new Map<Id, SObject>(someVar).getSomeClass().records`
* `SELECT Id FROM SBQQ__QuoteTerm__c WHERE SBQQ__StandardTerm__c = :CPQ_Hard_Coded_Ids__c.getInstance().Standard_Quote_Term_Id__c`
* `SELECT Id FROM Opportunity WHERE SBQQ__StandardTerm__c = :quotes[3].SBQQ__QuoteLine__r[0].Term__c`

resolves #155