### PR TITLE
getFlattenedFields issue with aliased fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.2.2
+
+August 1, 2021
+
+#160 - `getFlattenedFields()` Did not return correct results if a normal field used an alias, such as `SELECT Count(Id), Name account_name FROM Account GROUP BY Name`
+
 ## 4.2.1
 
 June 18, 2021

--- a/src/api/public-utils.ts
+++ b/src/api/public-utils.ts
@@ -178,7 +178,7 @@ export function getFlattenedFields(
     .flatMap(field => {
       switch (field.type) {
         case 'Field': {
-          return field.field;
+          return field.alias || field.field;
         }
         case 'FieldFunctionExpression': {
           let params = getParams(field);

--- a/test/public-utils-test-data.ts
+++ b/test/public-utils-test-data.ts
@@ -559,4 +559,34 @@ export const testCases: FlattenedObjTestCase[] = [
       Email: 'agreen@foo.com',
     },
   },
+  {
+    testCase: 16,
+    expectedFields: ['expr0', 'account_name'],
+    query: {
+      fields: [
+        {
+          type: 'FieldFunctionExpression',
+          functionName: 'COUNT',
+          parameters: ['Id'],
+          isAggregateFn: true,
+          rawValue: 'Count(Id)',
+        },
+        {
+          type: 'Field',
+          field: 'Name',
+          alias: 'account_name',
+        },
+      ],
+      sObject: 'Account',
+      groupBy: [
+        {
+          field: 'Name',
+        },
+      ],
+    },
+    sfdcObj: {
+      expr0: 10,
+      account_name: 'Account 1',
+    },
+  },
 ];


### PR DESCRIPTION
Ensure that if there is an alias on a field, that it is returned instead
of the field normal field value

resolves #160