### PR TITLE
Fix parser bug with GeoLocationUnit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.5
+
+June 11, 2022
+
+- Fixed parser error where `'mi'` and `'km'` could not be used in a WHERE clause because they were being parsed as a GeoLocationUnit (#188)
+  - Thank you @divijklenty for reporting this.
+
 ## 4.4
 
 March 11, 2022

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "soql-parser-js",
       "version": "4.4.0",
       "license": "MIT",
       "dependencies": {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -626,6 +626,9 @@ export class SoqlParser extends CstParser {
           { GATE: () => !isArray, ALT: () => this.SUBRULE(this.booleanValue) },
           { GATE: () => !isArray, ALT: () => this.CONSUME(lexer.DateLiteral) },
           { GATE: () => !isArray, ALT: () => this.SUBRULE(this.dateNLiteral) },
+          // GeolocationUnit is matched even when it is an actual string in a WHERE clause - treat as StringIdentifier
+          // https://github.com/paustint/soql-parser-js/issues/188
+          { GATE: () => !isArray, ALT: () => this.CONSUME(lexer.GeolocationUnit, { LABEL: 'StringIdentifier' }) },
           { GATE: () => !isArray, ALT: () => this.CONSUME(lexer.StringIdentifier) },
         ]),
     );
@@ -725,6 +728,7 @@ export class SoqlParser extends CstParser {
               { ALT: () => this.CONSUME(lexer.False, { LABEL: 'value' }) },
               { ALT: () => this.CONSUME(lexer.DateLiteral, { LABEL: 'value' }) },
               { ALT: () => this.SUBRULE(this.dateNLiteral, { LABEL: 'value' }) },
+              { ALT: () => this.CONSUME(lexer.GeolocationUnit, { LABEL: 'value' }) },
               { ALT: () => this.CONSUME(lexer.StringIdentifier, { LABEL: 'value' }) },
             ]),
         );

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -2390,6 +2390,113 @@ export const testCases: TestCase[] = [
       },
     },
   },
+  {
+    testCase: 118,
+    options: { allowApexBindVariables: true },
+    soql: `SELECT State_Abbr_c FROM Contact WHERE State_Abbr_c = 'MI' OR State_Abbr_c = 'km'`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'State_Abbr_c',
+        },
+      ],
+      sObject: 'Contact',
+      where: {
+        left: {
+          field: 'State_Abbr_c',
+          literalType: 'STRING',
+          operator: '=',
+          value: "'MI'",
+        },
+        operator: 'OR',
+        right: {
+          left: {
+            field: 'State_Abbr_c',
+            literalType: 'STRING',
+            operator: '=',
+            value: "'km'",
+          },
+        },
+      },
+    },
+  },
+  {
+    testCase: 119,
+    options: { allowApexBindVariables: true },
+    soql: `SELECT State_Abbr_c FROM Contact WHERE State_Abbr_c = 'KM'`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'State_Abbr_c',
+        },
+      ],
+      sObject: 'Contact',
+      where: {
+        left: {
+          field: 'State_Abbr_c',
+          literalType: 'STRING',
+          operator: '=',
+          value: "'KM'",
+        },
+      },
+    },
+  },
+  {
+    testCase: 120,
+    options: { allowApexBindVariables: true },
+    soql: `SELECT State_Abbr_c FROM Contact WHERE State_Abbr_c IN ('mi', 'KM')`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'State_Abbr_c',
+        },
+      ],
+      sObject: 'Contact',
+      where: {
+        left: {
+          field: 'State_Abbr_c',
+          literalType: 'STRING',
+          operator: 'IN',
+          value: ["'mi'", "'KM'"],
+        },
+      },
+    },
+  },
+  {
+    testCase: 121,
+    soql: "SELECT LeadSource, COUNT(Name) FROM Lead GROUP BY LeadSource HAVING COUNT(Name) > 100 AND LeadSource > 'km'",
+    output: {
+      fields: [
+        { type: 'Field', field: 'LeadSource' },
+        {
+          type: 'FieldFunctionExpression',
+          functionName: 'COUNT',
+          rawValue: 'COUNT(Name)',
+          isAggregateFn: true,
+          parameters: ['Name'],
+        },
+      ],
+      sObject: 'Lead',
+      groupBy: [
+        {
+          field: 'LeadSource',
+        },
+      ],
+      having: {
+        left: {
+          operator: '>',
+          value: '100',
+          literalType: 'INTEGER',
+          fn: { rawValue: 'COUNT(Name)', functionName: 'COUNT', parameters: ['Name'] },
+        },
+        operator: 'AND',
+        right: { left: { field: 'LeadSource', operator: '>', value: "'km'", literalType: 'STRING' } },
+      },
+    },
+  },
 ];
 
 export default testCases;

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -12,7 +12,7 @@ const replacements = [{ matching: / last /i, replace: ' LAST ' }];
 // Uncomment these to easily test one specific query - useful for troubleshooting/bugfixing
 
 // describe.only('parse queries', () => {
-//   const testCase = testCases.find(tc => tc.testCase === 117);
+//   const testCase = testCases.find(tc => tc.testCase === 118);
 //   it(`should correctly parse test case ${testCase.testCase} - ${testCase.soql}`, () => {
 //     const soqlQuery = parseQuery(testCase.soql, testCase.options);
 //     console.log(soqlQuery);


### PR DESCRIPTION
mi and km could not be used in WHERE clauses
because it was being identified as a GeolocationUnit instead of a string

resolves #188