### PR TITLE
Update documentation and CI configuration to use 'main' branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
-        name: Checkout [master]
+        name: Checkout [main]
         with:
           fetch-depth: 0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,11 @@ Any feature that is part of the core project and does not deviate from what the 
 # Making Changes
 
 - Fork the repository
-- Create a new branch from master (usually) and with a meaningful name for your changes
+- Create a new branch from main (usually) and with a meaningful name for your changes
 - Make your changes
 - Commit and push your change
   - Please run `prettier` on all modified files prior to opening your pull request
-- open a Pull Request for the master branch
+- open a Pull Request for the main branch
 
 # Re-generating parse after grammar change
 

--- a/README.md
+++ b/README.md
@@ -1013,4 +1013,4 @@ export interface WithDataCategoryCondition {
 
 ## Contributing
 
-All contributions are welcome on the project. Please read the [contribution guidelines](https://github.com/jetstreamapp/soql-parser-js/blob/master/CONTRIBUTING.md).
+All contributions are welcome on the project. Please read the [contribution guidelines](https://github.com/jetstreamapp/soql-parser-js/blob/main/CONTRIBUTING.md).

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -142,7 +142,7 @@ const soql = composeQuery({
 
 ## Contributing
 
-All contributions are welcome on the project. Please read the [contribution guidelines](https://github.com/paustint/soql-parser-js/blob/master/CONTRIBUTING.md).
+All contributions are welcome on the project. Please read the [contribution guidelines](https://github.com/paustint/soql-parser-js/blob/main/CONTRIBUTING.md).
 
 ## Data Models
 


### PR DESCRIPTION
Change all references from 'master' to 'main' in documentation and CI configuration to reflect the new branch naming convention.