### PR TITLE
Add support for comments in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 7.3.0
+
+Jul 16, 2026
+
+### Features
+
+- **Added support for line-level and block-level comments** — Queries may now contain comments, which are ignored during parsing: `//` runs to the end of the line and `/* ... */` may span multiple lines (non-nesting; an unterminated `/*` throws `Unterminated comment at position N`). Comment markers inside string literals (e.g. `WHERE Url = 'https://example.com'`) are treated as literal text. Comments are not represented in the parsed `Query`, so they are not preserved by `composeQuery`/`formatQuery`. Applies to all entry points (`parseQuery`, `isQueryValid`, partial parsing, and the CLI). Note that Salesforce itself does not accept comments in SOQL, so compose the parsed query before sending it to the Salesforce API.
+
 ## 7.2.2
 
 Jun 9, 2026

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ isQueryValid('SELECT Id Foo FROM Baz'); // false
 | composeQuery | Turn a Query object back into a SOQL statement.        | soql: Query<br> config?: SoqlComposeConfig |
 | formatQuery  | Format a SOQL query string.                            | soql: Query<br> config?: FormatOptions     |
 
+Queries may contain comments (`// single-line` and `/* multi-line */`), which are ignored during parsing. See [Comments in queries](#comments-in-queries) for details.
+
 ## Utility Functions
 
 **General Utility**
@@ -182,6 +184,29 @@ console.log(JSON.stringify(soqlQuery, null, 2));
 ```
 
 </details>
+
+### Comments in queries
+
+Queries passed to `parseQuery`, `isQueryValid`, and `formatQuery` may contain comments, which are ignored during parsing:
+
+- Single-line comments: everything from `//` through the end of the line
+- Multi-line comments: everything from `/*` through the closing `*/` (comments do not nest)
+
+Comment markers inside string literals are treated as literal text, e.g. `WHERE Url = 'https://example.com'` works as expected. Since comments are not represented in the parsed `Query`, they are not preserved when composing a query back to a string.
+
+> [!NOTE]
+> Salesforce itself does not support comments in SOQL, so strip or compose the query before sending it to the Salesforce API.
+
+```typescript
+import { parseQuery, composeQuery } from '@jetstreamapp/soql-parser-js';
+
+const soql = `
+  SELECT Id, Name // the fields we need
+  FROM Account /* the target object */
+`;
+
+composeQuery(parseQuery(soql)); // SELECT Id, Name FROM Account
+```
 
 ### Parsing a partial query
 

--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -539,7 +539,44 @@ export function tokenize(input: string): Token[] {
       continue;
     }
 
-    // 2. String literal: '...' with backslash escape handling
+    // 2. Skip comments: // to end of line, /* ... */ (non-nesting)
+    if (ch === 47) {
+      // forward slash
+      const next = pos + 1 < len ? input.charCodeAt(pos + 1) : 0;
+      if (next === 47) {
+        // '//' - consume to end of line or end of input
+        pos += 2;
+        while (pos < len) {
+          const c = input.charCodeAt(pos);
+          if (c === 10 || c === 13) {
+            break; // leave newline for whitespace skip
+          }
+          pos++;
+        }
+        continue;
+      }
+      if (next === 42) {
+        // '/*' - consume until '*/'
+        const start = pos;
+        pos += 2;
+        let terminated = false;
+        while (pos < len) {
+          if (input.charCodeAt(pos) === 42 && pos + 1 < len && input.charCodeAt(pos + 1) === 47) {
+            pos += 2;
+            terminated = true;
+            break;
+          }
+          pos++;
+        }
+        if (!terminated) {
+          throw new Error(`Unterminated comment at position ${start}`);
+        }
+        continue;
+      }
+      // lone '/' falls through to the "Unexpected character" throw below
+    }
+
+    // 3. String literal: '...' with backslash escape handling
     if (ch === 39) {
       // single quote
       const start = pos;
@@ -570,7 +607,7 @@ export function tokenize(input: string): Token[] {
       continue;
     }
 
-    // 3. Check for DateTime/Date (starts with a digit, could be date/datetime or number)
+    // 4. Check for DateTime/Date (starts with a digit, could be date/datetime or number)
     if (isDigit(ch)) {
       // Try to match datetime or date pattern: YYYY-MM-DD...
       if (pos + 9 < len && input.charCodeAt(pos + 4) === 45 && input.charCodeAt(pos + 7) === 45) {
@@ -670,7 +707,7 @@ export function tokenize(input: string): Token[] {
       continue;
     }
 
-    // 4. Multi-char and single-char operators/symbols
+    // 5. Multi-char and single-char operators/symbols
     if (ch === 33) {
       // !
       if (pos + 1 < len && input.charCodeAt(pos + 1) === 61) {
@@ -825,7 +862,7 @@ export function tokenize(input: string): Token[] {
       continue;
     }
 
-    // 5. Identifiers and keywords
+    // 6. Identifiers and keywords
     if (isAlpha(ch)) {
       const start = pos;
       pos++;

--- a/test/lexer.spec.ts
+++ b/test/lexer.spec.ts
@@ -403,6 +403,126 @@ describe('Lexer - string literals', () => {
 });
 
 // ===========================================================================
+// Comments
+// ===========================================================================
+
+describe('Lexer - comments', () => {
+  it('should skip a single-line comment at the end of input without a trailing newline', () => {
+    const tokens = tokenize('SELECT Id FROM Account // trailing comment');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should skip a single-line comment terminated by LF', () => {
+    const tokens = tokenize('SELECT Id // fields\nFROM Account');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should skip a single-line comment terminated by CRLF', () => {
+    const tokens = tokenize('SELECT Id // fields\r\nFROM Account');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should skip a single-line comment on its own line', () => {
+    const tokens = tokenize('SELECT Id\n// a whole line comment\nFROM Account');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should produce only EOF for comment-only input', () => {
+    const tokens = tokenize('// nothing but a comment');
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].kind).toBe(TokenKind.EOF);
+  });
+
+  it('should skip an inline multi-line comment between tokens', () => {
+    const tokens = tokenize('SELECT /* fields */ Id FROM Account');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should skip a multi-line comment spanning multiple lines', () => {
+    const tokens = tokenize('SELECT Id\n/* this comment\nspans several\nlines */\nFROM Account');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should skip multi-line comments at the start and end of input', () => {
+    const tokens = tokenize('/* start */ SELECT Id FROM Account /* end */');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should skip the minimal empty multi-line comment', () => {
+    const tokens = tokenize('SELECT/**/Id FROM Account');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should not treat */ inside a single-line comment specially', () => {
+    const tokens = tokenize('SELECT Id // has */ in it\nFROM Account');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should not nest multi-line comments (first */ closes)', () => {
+    const tokens = tokenize('SELECT /* outer /* inner */ Id FROM Account');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should ignore // inside a multi-line comment', () => {
+    const tokens = tokenize('SELECT /* has // inside */ Id FROM Account');
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account']);
+  });
+
+  it('should NOT treat // inside a string literal as a comment', () => {
+    const tokens = tokenize("SELECT Id FROM Account WHERE Url = 'http://example.com'");
+    const literal = tokens.find(t => t.kind === TokenKind.STRING_LITERAL);
+    expect(literal?.text).toBe("'http://example.com'");
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account', 'WHERE', 'Url', '=', "'http://example.com'"]);
+  });
+
+  it('should NOT treat /* */ inside a string literal as a comment', () => {
+    const tokens = tokenize("SELECT Id FROM Account WHERE Name = 'a /* not a comment */ b'");
+    const literal = tokens.find(t => t.kind === TokenKind.STRING_LITERAL);
+    expect(literal?.text).toBe("'a /* not a comment */ b'");
+  });
+
+  it('should tokenize a string literal containing only a comment marker', () => {
+    const tokens = tokenize("SELECT Id FROM Account WHERE Name = '//'");
+    const literal = tokens.find(t => t.kind === TokenKind.STRING_LITERAL);
+    expect(literal?.text).toBe("'//'");
+  });
+
+  it('should NOT treat comment markers after an escaped quote in a string as a comment', () => {
+    const tokens = tokenize("SELECT Id FROM Account WHERE Name = 'it\\'s http://x /* here */'");
+    const literal = tokens.find(t => t.kind === TokenKind.STRING_LITERAL);
+    expect(literal?.text).toBe("'it\\'s http://x /* here */'");
+  });
+
+  it('should NOT treat a lone */ inside a string literal specially', () => {
+    const tokens = tokenize("SELECT Id FROM Account WHERE Name = 'ends */ here'");
+    const literal = tokens.find(t => t.kind === TokenKind.STRING_LITERAL);
+    expect(literal?.text).toBe("'ends */ here'");
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account', 'WHERE', 'Name', '=', "'ends */ here'"]);
+  });
+
+  it('should handle real comments alongside strings containing comment markers', () => {
+    const tokens = tokenize("SELECT Id // real comment\nFROM Account WHERE Url = 'http://x' /* real */ AND Name = 'a // b'");
+    expect(texts(tokens)).toEqual(['SELECT', 'Id', 'FROM', 'Account', 'WHERE', 'Url', '=', "'http://x'", 'AND', 'Name', '=', "'a // b'"]);
+  });
+
+  it('should preserve original input offsets for tokens after a comment', () => {
+    const soql = '/* lead */ SELECT Id';
+    const tokens = tokenize(soql);
+    expect(tokens[0].kind).toBe(TokenKind.SELECT);
+    expect(tokens[0].start).toBe(soql.indexOf('SELECT'));
+    expect(tokens[1].start).toBe(soql.indexOf('Id'));
+  });
+
+  it('should throw for an unterminated multi-line comment', () => {
+    expect(() => tokenize('SELECT /* oops')).toThrow('Unterminated comment at position 7');
+  });
+
+  it('should still throw for a lone forward slash', () => {
+    expect(() => tokenize('SELECT Id / FROM Account')).toThrow(/Unexpected character/);
+  });
+});
+
+// ===========================================================================
 // Date and DateTime tokens
 // ===========================================================================
 

--- a/test/test-cases-for-is-valid.ts
+++ b/test/test-cases-for-is-valid.ts
@@ -499,5 +499,10 @@ WHERE
   { testCase: 164, soql: `SELECT Id FROM Account USING SCOPE my_territory`, isValid: true },
   { testCase: 165, soql: `SELECT Id FROM Account USING SCOPE my_team_territory`, isValid: true },
   { testCase: 166, soql: `SELECT Id, Name FROM Account USING SCOPE myRule`, isValid: true },
+  {
+    testCase: 167,
+    soql: `SELECT Id // single-line comment\nFROM Account /* multi-line\ncomment */ WHERE Name = 'has // and /* inside */'`,
+    isValid: true,
+  },
 ];
 export default testCases;

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -2783,6 +2783,66 @@ export const testCases: TestCase[] = [
       usingScope: 'myRule',
     },
   },
+  {
+    testCase: 139,
+    soql: 'SELECT Id, Name // the fields we need\nFROM Account // the target object',
+    soqlComposed: 'SELECT Id, Name FROM Account',
+    output: {
+      fields: [
+        { type: 'Field', field: 'Id' },
+        { type: 'Field', field: 'Name' },
+      ],
+      sObject: 'Account',
+    },
+  },
+  {
+    testCase: 140,
+    soql: "/* leading comment */ SELECT Id /* inline\ncomment */ FROM Account WHERE Website = 'https://example.com' /* trailing comment */",
+    soqlComposed: "SELECT Id FROM Account WHERE Website = 'https://example.com'",
+    output: {
+      fields: [{ type: 'Field', field: 'Id' }],
+      sObject: 'Account',
+      where: {
+        left: {
+          field: 'Website',
+          operator: '=',
+          value: "'https://example.com'",
+          literalType: 'STRING',
+        },
+      },
+    },
+  },
+  {
+    testCase: 141,
+    soql: "SELECT Id FROM Account WHERE Name = 'not // a comment' AND Description = 'still /* not */ a comment'",
+    output: {
+      fields: [{ type: 'Field', field: 'Id' }],
+      sObject: 'Account',
+      where: {
+        left: { field: 'Name', operator: '=', value: "'not // a comment'", literalType: 'STRING' },
+        operator: 'AND',
+        right: {
+          left: { field: 'Description', operator: '=', value: "'still /* not */ a comment'", literalType: 'STRING' },
+        },
+      },
+    },
+  },
+  {
+    testCase: 142,
+    soql: "SELECT Id // real comment\nFROM Account /* real\ncomment */ WHERE Website = 'http://example.com' AND Name = 'a /* fake */ // comment'",
+    soqlComposed: "SELECT Id FROM Account WHERE Website = 'http://example.com' AND Name = 'a /* fake */ // comment'",
+    output: {
+      fields: [{ type: 'Field', field: 'Id' }],
+      sObject: 'Account',
+      where: {
+        left: { field: 'Website', operator: '=', value: "'http://example.com'", literalType: 'STRING' },
+        operator: 'AND',
+        right: {
+          left: { field: 'Name', operator: '=', value: "'a /* fake */ // comment'", literalType: 'STRING' },
+        },
+      },
+    },
+  },
 ];
 
 export default testCases;


### PR DESCRIPTION
Introduce support for line-level and block-level comments in queries. Comments are ignored during parsing and do not affect the output of the composed query. This feature enhances the usability of the query syntax while ensuring compatibility with Salesforce's requirements.