### PR TITLE
Update release process to use GitHub App token and add version polling script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Jetstream Bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout [main]
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - name: Init npm cache
         uses: actions/setup-node@v6
         with:
@@ -41,4 +48,4 @@ jobs:
         run: npm run release -- "$INCREMENT" --ci
         env:
           INCREMENT: ${{ github.event.inputs.increment }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.release-it.json
+++ b/.release-it.json
@@ -12,6 +12,6 @@
   "hooks": {
     "before:init": ["npm run build", "npm test"],
     "after:bump": ["npm run build", "npm pack"],
-    "after:release": "npm run copy-tc-to-docs && cd docs && npm install @jetstreamapp/soql-parser-js@${version} && git add package*.json && git add static/sample-queries-json.json && git commit -m \"Updated docs version\" && git push && npm run deploy"
+    "after:release": "npm run copy-tc-to-docs && node tasks/wait-for-npm-version.mjs ${version} && cd docs && npm install @jetstreamapp/soql-parser-js@${version} --prefer-online && git add package*.json && git add static/sample-queries-json.json && git commit -m \"Updated docs version\" && git push && npm run deploy"
   }
 }

--- a/tasks/wait-for-npm-version.mjs
+++ b/tasks/wait-for-npm-version.mjs
@@ -1,0 +1,61 @@
+/**
+ * Wait until a version of this package is installable from the npm registry.
+ * A freshly published version is not immediately available, so the release
+ * process (.release-it.json after:release hook) polls before installing it in docs.
+ *
+ * Usage: node tasks/wait-for-npm-version.mjs <version> [timeoutSeconds]
+ */
+import { readFileSync } from 'node:fs';
+
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+
+const version = process.argv[2];
+const timeoutSeconds = Number(process.argv[3] ?? 600);
+const pollIntervalSeconds = 15;
+
+if (!version) {
+  console.error('Usage: node tasks/wait-for-npm-version.mjs <version> [timeoutSeconds]');
+  process.exit(1);
+}
+
+if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+  console.error(`Invalid timeoutSeconds: ${process.argv[3]}`);
+  process.exit(1);
+}
+
+const registryUrl = `https://registry.npmjs.org/${pkg.name.replaceAll('/', '%2F')}`;
+const deadline = Date.now() + timeoutSeconds * 1000;
+
+const sleep = (seconds) => new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+
+async function isVersionAvailable() {
+  try {
+    const response = await fetch(registryUrl, {
+      // Abbreviated metadata - same document npm install resolves against
+      headers: { accept: 'application/vnd.npm.install-v1+json' },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) {
+      console.warn(`Registry responded with HTTP ${response.status}`);
+      return false;
+    }
+    const data = await response.json();
+    return Boolean(data.versions?.[version]);
+  } catch (err) {
+    console.warn(`Registry request failed: ${err?.message ?? err}`);
+    return false;
+  }
+}
+
+console.log(`Waiting up to ${timeoutSeconds}s for ${pkg.name}@${version} to be available on npm...`);
+
+while (!(await isVersionAvailable())) {
+  if (Date.now() >= deadline) {
+    console.error(`Timed out after ${timeoutSeconds}s waiting for ${pkg.name}@${version}.`);
+    process.exit(1);
+  }
+  console.log(`${pkg.name}@${version} not yet available, retrying in ${pollIntervalSeconds}s...`);
+  await sleep(pollIntervalSeconds);
+}
+
+console.log(`${pkg.name}@${version} is available.`);


### PR DESCRIPTION
Enhance the release process by utilizing a GitHub App token for authentication and introducing a script that polls the npm registry to ensure the availability of newly published package versions before proceeding with the release.