### PR TITLE
Add comment stripping support for SOQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 7.4.0
+
+Jul 16, 2026
+
+### Features
+
+- **Added comment utilities: `stripComments`, `hasComments`, and `getComments`** — These operate on the raw query string without parsing it, so they work on any input (including invalid SOQL) and never throw. `stripComments` removes comments without otherwise modifying the query — no reformatting, no whitespace or keyword normalization — making it safe for proxying user-authored queries to the Salesforce API, which does not accept comments. When the query contains no comments, the original string is returned as-is, so it can be called unconditionally. A single space is inserted where removing a comment would otherwise merge adjacent tokens (`SELECT Id/*c*/FROM Account` → `SELECT Id FROM Account`). Comment markers inside string literals are treated as literal text, and an unterminated `/*` is stripped through the end of the input rather than throwing. `hasComments` returns whether a query contains any comments, and `getComments` returns each comment's type (`line` | `block`), text, and position.
+
 ## 7.3.0
 
 Jul 16, 2026

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Many of hte utility functions are provided to easily determine the shape of spec
 | hasAlias                                | Returns `true` if the field passed in has the `alias` property.                                                                                                                                                         | input: `string \| ComposeFieldInput`                                        |
 | getField                                | Convenience method to construct fields in the correct format when using `composeQuery()`. Look in the data models section below for the structure of `ComposeFieldInput`.                                               | input: `string \| ComposeFieldInput`                                        |
 | getFlattenedFields                      | Flatten a Salesforce record based on the parsed SOQL Query. this is useful if you have relationships in your query and want to show the results in a table, using `.` dot notation for the relationship field headings. | soql: `Query \| Subquery \| FieldSubquery`<br> config?: `SoqlComposeConfig` |
+| hasComments                             | Returns `true` if the query string contains at least one comment. Operates on the raw string without parsing it, so it works on any input and never throws.                                                             | soql: `string`                                                              |
+| getComments                             | Returns all comments in the query string (type, text, and position), in order of appearance. Operates on the raw string without parsing it, so it works on any input and never throws.                                  | soql: `string`                                                              |
+| stripComments                           | Removes comments from a query string without otherwise modifying it. Returns the original string as-is if there are no comments. See [Comments in queries](#comments-in-queries).                                       | soql: `string`                                                              |
 | isSubquery                              | Returns `true` if the data passed in is a subquery.                                                                                                                                                                     | query: `Query \| Subquery`                                                  |
 | isFieldSubquery                         | Returns `true` if the data passed in is a FieldSubquery.                                                                                                                                                                | value: `any`                                                                |
 | isWhereClauseWithRightCondition         | Returns `true` if the value passed in is a `WhereClause` with an `operator` and `right` property                                                                                                                        | value: `WhereClause`                                                        |
@@ -206,6 +209,30 @@ const soql = `
 `;
 
 composeQuery(parseQuery(soql)); // SELECT Id, Name FROM Account
+```
+
+If you want to remove comments from a query **without otherwise modifying it** (no reformatting, no whitespace or keyword normalization), use `stripComments`. It operates on the raw string without parsing it, so it works even on invalid SOQL and never throws — an unterminated `/*` is stripped through the end of the input rather than throwing like `parseQuery` does. When the query contains no comments the original string is returned unchanged, so it is safe to call on every query before sending it to the Salesforce API. A single space is inserted where removing a comment would otherwise merge adjacent tokens.
+
+`hasComments` and `getComments` follow the same rules and can be used to detect or inspect comments without modifying the query.
+
+```typescript
+import { stripComments, hasComments, getComments } from '@jetstreamapp/soql-parser-js';
+
+stripComments(`SELECT Id, Name // the fields we need
+FROM Account`);
+// 'SELECT Id, Name \nFROM Account'
+
+stripComments('SELECT Id/* comment */FROM Account'); // 'SELECT Id FROM Account'
+
+const soql = "SELECT Id FROM Account WHERE Url = 'https://example.com'";
+stripComments(soql) === soql; // true - no comments, original string returned as-is
+hasComments(soql); // false
+
+getComments('SELECT Id /* fields */ FROM Account // trailing');
+// [
+//   { type: 'block', text: '/* fields */', start: 10, end: 22 },
+//   { type: 'line', text: '// trailing', start: 36, end: 47 },
+// ]
 ```
 
 ### Parsing a partial query
@@ -537,10 +564,10 @@ WHERE Name LIKE 'a%'
 
 The library can be used as a Lightning Web Component in your Salesforce org. The build produces two artifacts to support different workflows:
 
-| Artifact                                    | What it is                                                                 | Best for                                                              |
-| ------------------------------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `dist/lwc/soqlParserJs.js`                  | Standalone bundled JS file (no metadata)                                   | SFDX projects — drop into your existing `lwc/soqlParserJs/` folder    |
-| `dist/lwc-packaged/` (and the release zip)  | Full Salesforce metadata package: `package.xml` + `lwc/soqlParserJs/{js,js-meta.xml}` | Direct deployment to an org via `sf project deploy start` — no SFDX project required |
+| Artifact                                   | What it is                                                                            | Best for                                                                             |
+| ------------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `dist/lwc/soqlParserJs.js`                 | Standalone bundled JS file (no metadata)                                              | SFDX projects — drop into your existing `lwc/soqlParserJs/` folder                   |
+| `dist/lwc-packaged/` (and the release zip) | Full Salesforce metadata package: `package.xml` + `lwc/soqlParserJs/{js,js-meta.xml}` | Direct deployment to an org via `sf project deploy start` — no SFDX project required |
 
 The Salesforce API version used for the metadata package is configured via the `salesforceApiVersion` field in [package.json](package.json) and is applied to both `package.xml` and `soqlParserJs.js-meta.xml` at build time.
 
@@ -615,6 +642,8 @@ export default class MyComponent extends LightningElement {
 }
 ```
 
+<!-- LWC event bindings must be unquoted (onclick={handleClick}); prettier would add quotes -->
+<!-- prettier-ignore -->
 ```html
 <template>
   <button class="slds-button slds-button_neutral" onclick={handleClick}>Click Me</button>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@
  * a copy of which has been included with this distribution in the LICENSE.txt file.
  */
 export { parseQuery, isQueryValid } from './parser/parser';
+export { getComments, hasComments, stripComments } from './parser/comments';
+export type { SoqlComment } from './parser/comments';
 export * from './api/api-models';
 export * from './api/public-utils';
 export * from './composer/composer';

--- a/src/parser/comments.ts
+++ b/src/parser/comments.ts
@@ -1,0 +1,153 @@
+/**
+ * Comment utilities that operate on the raw query string without parsing it.
+ *
+ * These intentionally do NOT share the lexer's scanner: the lexer is strict
+ * (it throws on unterminated comments and unexpected characters), while these
+ * utilities are lenient so they can be safely applied to any string - including
+ * invalid SOQL - without throwing. Only two constructs are recognized:
+ * string literals ('...' with backslash escapes, so comment markers inside
+ * strings are never treated as comments) and the two comment forms.
+ */
+
+export interface SoqlComment {
+  type: 'line' | 'block';
+  /** Full comment text, including the `//` or `/* *\/` delimiters */
+  text: string;
+  /** Index of the first character of the comment in the input string */
+  start: number;
+  /** Index just past the last character of the comment (exclusive) */
+  end: number;
+}
+
+function isWhitespaceChar(ch: number): boolean {
+  return ch === 32 || ch === 9 || ch === 10 || ch === 13 || ch === 12; // space, tab, LF, CR, FF
+}
+
+function scanComments(input: string, stopAfterFirst: boolean): SoqlComment[] {
+  const comments: SoqlComment[] = [];
+  const len = input.length;
+  let pos = 0;
+
+  while (pos < len) {
+    const ch = input.charCodeAt(pos);
+
+    // String literal: '...' with backslash escape handling (same rules as the
+    // lexer) so comment markers inside strings are skipped over. An unterminated
+    // string consumes the rest of the input.
+    if (ch === 39) {
+      // single quote
+      pos++;
+      while (pos < len) {
+        const c = input.charCodeAt(pos);
+        if (c === 92) {
+          // backslash - skip next character
+          pos += 2;
+          continue;
+        }
+        if (c === 39) {
+          pos++;
+          break;
+        }
+        pos++;
+      }
+      continue;
+    }
+
+    if (ch === 47) {
+      // forward slash
+      const next = pos + 1 < len ? input.charCodeAt(pos + 1) : 0;
+      if (next === 47) {
+        // '//' - line comment runs to end of line or end of input; the newline
+        // is not part of the comment
+        const start = pos;
+        pos += 2;
+        while (pos < len) {
+          const c = input.charCodeAt(pos);
+          if (c === 10 || c === 13) {
+            break;
+          }
+          pos++;
+        }
+        comments.push({ type: 'line', text: input.substring(start, pos), start, end: pos });
+        if (stopAfterFirst) {
+          return comments;
+        }
+        continue;
+      }
+      if (next === 42) {
+        // '/*' - block comment runs through '*/' (non-nesting); an unterminated
+        // comment runs to end of input rather than throwing
+        const start = pos;
+        pos += 2;
+        while (pos < len) {
+          if (input.charCodeAt(pos) === 42 && pos + 1 < len && input.charCodeAt(pos + 1) === 47) {
+            pos += 2;
+            break;
+          }
+          pos++;
+        }
+        comments.push({ type: 'block', text: input.substring(start, pos), start, end: pos });
+        if (stopAfterFirst) {
+          return comments;
+        }
+        continue;
+      }
+    }
+
+    pos++;
+  }
+
+  return comments;
+}
+
+/**
+ * Returns all comments found in a query string, in order of appearance.
+ * Does not parse or validate the query and never throws.
+ * @param soql raw query string (does not need to be valid SOQL)
+ * @returns comments with their type, text (including delimiters), and position
+ */
+export function getComments(soql: string): SoqlComment[] {
+  return scanComments(soql, false);
+}
+
+/**
+ * Returns `true` if the query string contains at least one comment.
+ * Does not parse or validate the query and never throws.
+ * @param soql raw query string (does not need to be valid SOQL)
+ */
+export function hasComments(soql: string): boolean {
+  return scanComments(soql, true).length > 0;
+}
+
+/**
+ * Removes all comments from a query string without otherwise modifying it -
+ * no parsing, no reformatting, no whitespace or keyword normalization.
+ * If the string contains no comments, the original string is returned as-is,
+ * so this is safe to call unconditionally on every query.
+ *
+ * A single space is inserted in place of a removed comment when it directly
+ * touched non-whitespace on both sides (e.g. `SELECT Id/*c*\/FROM` becomes
+ * `SELECT Id FROM`) so adjacent tokens are never merged. Whitespace that
+ * surrounded a comment is left as-is.
+ * @param soql raw query string (does not need to be valid SOQL)
+ * @returns the query with comments removed, or the original string if there were none
+ */
+export function stripComments(soql: string): string {
+  const comments = scanComments(soql, false);
+  if (comments.length === 0) {
+    return soql;
+  }
+  let output = '';
+  let prevEnd = 0;
+  for (const comment of comments) {
+    output += soql.substring(prevEnd, comment.start);
+    const charBefore = output.length > 0 ? output.charCodeAt(output.length - 1) : 0;
+    const charAfter = comment.end < soql.length ? soql.charCodeAt(comment.end) : 0;
+    if (charBefore !== 0 && !isWhitespaceChar(charBefore) && charAfter !== 0 && !isWhitespaceChar(charAfter)) {
+      output += ' ';
+    }
+    prevEnd = comment.end;
+  }
+  output += soql.substring(prevEnd);
+  return output;
+}

--- a/test/comments.spec.ts
+++ b/test/comments.spec.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import { getComments, hasComments, stripComments } from '../src/parser/comments';
+
+// ===========================================================================
+// stripComments
+// ===========================================================================
+
+describe('stripComments - queries without comments', () => {
+  it('should return the original string reference when there are no comments', () => {
+    const soql = "SELECT Id, Name FROM Account WHERE Name = 'test'";
+    expect(stripComments(soql)).toBe(soql);
+  });
+
+  it('should return the original string reference for an empty string', () => {
+    const soql = '';
+    expect(stripComments(soql)).toBe(soql);
+  });
+
+  it('should NOT treat // inside a string literal as a comment', () => {
+    const soql = "SELECT Id FROM Account WHERE Url = 'http://example.com'";
+    expect(stripComments(soql)).toBe(soql);
+  });
+
+  it('should NOT treat /* */ inside a string literal as a comment', () => {
+    const soql = "SELECT Id FROM Account WHERE Name = 'a /* not a comment */ b'";
+    expect(stripComments(soql)).toBe(soql);
+  });
+
+  it('should respect escaped quotes inside string literals', () => {
+    const soql = "SELECT Id FROM Account WHERE Name = 'it\\'s // still a string'";
+    expect(stripComments(soql)).toBe(soql);
+  });
+
+  it('should treat an unterminated string literal as a string through end of input', () => {
+    const soql = "SELECT Id FROM Account WHERE Name = 'unterminated // not a comment";
+    expect(stripComments(soql)).toBe(soql);
+  });
+
+  it('should not modify a lone forward slash', () => {
+    const soql = 'SELECT Id FROM Account WHERE Ratio__c = 1 / 2';
+    expect(stripComments(soql)).toBe(soql);
+  });
+});
+
+describe('stripComments - line comments', () => {
+  it('should strip a trailing line comment without a newline', () => {
+    expect(stripComments('SELECT Id FROM Account // trailing comment')).toBe('SELECT Id FROM Account ');
+  });
+
+  it('should strip a line comment and preserve the LF', () => {
+    expect(stripComments('SELECT Id // fields\nFROM Account')).toBe('SELECT Id \nFROM Account');
+  });
+
+  it('should strip a line comment and preserve the CRLF', () => {
+    expect(stripComments('SELECT Id // fields\r\nFROM Account')).toBe('SELECT Id \r\nFROM Account');
+  });
+
+  it('should strip a whole-line comment but leave the blank line', () => {
+    expect(stripComments('SELECT Id\n// a whole line comment\nFROM Account')).toBe('SELECT Id\n\nFROM Account');
+  });
+
+  it('should strip comment-only input to an empty string', () => {
+    expect(stripComments('// nothing but a comment')).toBe('');
+  });
+
+  it('should not treat */ inside a line comment specially', () => {
+    expect(stripComments('SELECT Id // has */ in it\nFROM Account')).toBe('SELECT Id \nFROM Account');
+  });
+});
+
+describe('stripComments - block comments', () => {
+  it('should strip an inline block comment surrounded by spaces, preserving the spaces', () => {
+    expect(stripComments('SELECT /* fields */ Id FROM Account')).toBe('SELECT  Id FROM Account');
+  });
+
+  it('should strip a block comment spanning multiple lines', () => {
+    expect(stripComments('SELECT Id\n/* this comment\nspans several\nlines */\nFROM Account')).toBe('SELECT Id\n\nFROM Account');
+  });
+
+  it('should strip block comments at the start and end of input', () => {
+    expect(stripComments('/* start */ SELECT Id FROM Account /* end */')).toBe(' SELECT Id FROM Account ');
+  });
+
+  it('should insert a space when a removed comment directly touched tokens on both sides', () => {
+    expect(stripComments('SELECT Id/*c*/FROM Account')).toBe('SELECT Id FROM Account');
+  });
+
+  it('should insert a space for the minimal empty block comment between tokens', () => {
+    expect(stripComments('SELECT/**/Id FROM Account')).toBe('SELECT Id FROM Account');
+  });
+
+  it('should not double-space adjacent block comments between tokens', () => {
+    expect(stripComments('SELECT/**//**/Id FROM Account')).toBe('SELECT Id FROM Account');
+  });
+
+  it('should not insert a space when the comment is at the start of input', () => {
+    expect(stripComments('/*c*/SELECT Id FROM Account')).toBe('SELECT Id FROM Account');
+  });
+
+  it('should not insert a space when the comment is at the end of input', () => {
+    expect(stripComments('SELECT Id FROM Account/*c*/')).toBe('SELECT Id FROM Account');
+  });
+
+  it('should not nest block comments (first */ closes)', () => {
+    expect(stripComments('SELECT /* outer /* inner */ Id FROM Account')).toBe('SELECT  Id FROM Account');
+  });
+
+  it('should ignore // inside a block comment', () => {
+    expect(stripComments('SELECT /* has // inside */ Id FROM Account')).toBe('SELECT  Id FROM Account');
+  });
+
+  it('should strip an unterminated block comment through end of input without throwing', () => {
+    expect(stripComments('SELECT Id FROM Account /* unterminated')).toBe('SELECT Id FROM Account ');
+  });
+
+  it('should strip comments containing string quotes', () => {
+    expect(stripComments("SELECT Id /* don't */ FROM Account")).toBe('SELECT Id  FROM Account');
+  });
+});
+
+describe('stripComments - non-SOQL input', () => {
+  it('should never throw on arbitrary text', () => {
+    expect(stripComments('this is not soql // comment')).toBe('this is not soql ');
+    expect(stripComments('random / slash and { braces }')).toBe('random / slash and { braces }');
+  });
+});
+
+// ===========================================================================
+// hasComments
+// ===========================================================================
+
+describe('hasComments', () => {
+  it('should return false for a query without comments', () => {
+    expect(hasComments('SELECT Id FROM Account')).toBe(false);
+  });
+
+  it('should return false for an empty string', () => {
+    expect(hasComments('')).toBe(false);
+  });
+
+  it('should return true for a line comment', () => {
+    expect(hasComments('SELECT Id FROM Account // comment')).toBe(true);
+  });
+
+  it('should return true for a block comment', () => {
+    expect(hasComments('SELECT /* fields */ Id FROM Account')).toBe(true);
+  });
+
+  it('should return true for an unterminated block comment', () => {
+    expect(hasComments('SELECT Id FROM Account /* unterminated')).toBe(true);
+  });
+
+  it('should return false when comment markers only appear inside string literals', () => {
+    expect(hasComments("SELECT Id FROM Account WHERE Url = 'http://example.com'")).toBe(false);
+    expect(hasComments("SELECT Id FROM Account WHERE Name = '/* nope */'")).toBe(false);
+  });
+});
+
+// ===========================================================================
+// getComments
+// ===========================================================================
+
+describe('getComments', () => {
+  it('should return an empty array for a query without comments', () => {
+    expect(getComments('SELECT Id FROM Account')).toEqual([]);
+  });
+
+  it('should return line comment with text and position', () => {
+    const soql = 'SELECT Id FROM Account // trailing';
+    expect(getComments(soql)).toEqual([{ type: 'line', text: '// trailing', start: 23, end: 34 }]);
+  });
+
+  it('should not include the newline in a line comment', () => {
+    const soql = 'SELECT Id // fields\nFROM Account';
+    const [comment] = getComments(soql);
+    expect(comment.text).toBe('// fields');
+    expect(soql.charAt(comment.end)).toBe('\n');
+  });
+
+  it('should return block comment including delimiters', () => {
+    const soql = 'SELECT /* fields */ Id FROM Account';
+    expect(getComments(soql)).toEqual([{ type: 'block', text: '/* fields */', start: 7, end: 19 }]);
+  });
+
+  it('should return multiple comments in order of appearance', () => {
+    const soql = '/* start */ SELECT Id // middle\nFROM Account /* end */';
+    const comments = getComments(soql);
+    expect(comments.map(c => c.text)).toEqual(['/* start */', '// middle', '/* end */']);
+    expect(comments.map(c => c.type)).toEqual(['block', 'line', 'block']);
+  });
+
+  it('should return an unterminated block comment running through end of input', () => {
+    const soql = 'SELECT Id /* unterminated';
+    expect(getComments(soql)).toEqual([{ type: 'block', text: '/* unterminated', start: 10, end: soql.length }]);
+  });
+
+  it('should reconstruct the original string from positions', () => {
+    const soql = 'SELECT /* a */ Id // b\nFROM Account';
+    for (const comment of getComments(soql)) {
+      expect(soql.substring(comment.start, comment.end)).toBe(comment.text);
+    }
+  });
+});


### PR DESCRIPTION
Introduce utilities for handling comments in SOQL queries, including functions to strip comments, check for their presence, and retrieve them without parsing the query. This ensures safe processing of user-authored queries for the Salesforce API.